### PR TITLE
Handle null valuenum without mapping to an abnormally high HPO term

### DIFF
--- a/src/main/java/org/jax/Entity/LabEvent.java
+++ b/src/main/java/org/jax/Entity/LabEvent.java
@@ -24,13 +24,13 @@ public class LabEvent {
     @Column(name = "VALUE")
     private String value;
     @Column(name = "VALUENUM")
-    private double value_num;
+    private Double value_num;
     @Column(name = "VALUEUOM")
     private String value_uom;
     @Column(name = "FLAG")
     private String flag;
 
-    public LabEvent(int row_id, int subject_id, int hadm_id, int item_id, Timestamp chart_time, String value, double value_num, String value_uom, String flag) {
+    public LabEvent(int row_id, int subject_id, int hadm_id, int item_id, Timestamp chart_time, String value, Double value_num, String value_uom, String flag) {
         this.row_id = row_id;
         this.subject_id = subject_id;
         this.hadm_id = hadm_id;
@@ -90,11 +90,11 @@ public class LabEvent {
         this.value = value;
     }
 
-    public double getValue_num() {
+    public Double getValue_num() {
         return value_num;
     }
 
-    public void setValue_num(double value_num) {
+    public void setValue_num(Double value_num) {
         this.value_num = value_num;
     }
 

--- a/src/main/java/org/jax/io/LabEventFactory.java
+++ b/src/main/java/org/jax/io/LabEventFactory.java
@@ -40,11 +40,11 @@ public class LabEventFactory {
             int item_id = Integer.parseInt(elements[3]);
             Timestamp charttime = Timestamp.valueOf(elements[4]);
             String value = elements[5].trim().replace("\"", "");
-            float valuenum;
-            if (elements[6].isEmpty()) {
-                valuenum = Float.MAX_VALUE;
+            Double valuenum;
+            if (StringUtils.isBlank(elements[6])) {
+                valuenum = null;
             } else {
-                valuenum = Float.parseFloat(elements[6].trim());
+                valuenum = Double.parseDouble(elements[6].trim());
             }
             String valueuom = elements[7].trim().replace("\"", "");
             String flag = elements[8].trim().replace("\"", "");
@@ -72,11 +72,11 @@ public class LabEventFactory {
 		int item_id = rs.getInt("ITEMID");
 		Timestamp charttime = rs.getTimestamp("CHARTTIME");
 		String value = ResultSetUtil.getStringOrBlank(rs, "VALUE").trim().replace("\"", "");
-        float valuenum;
+        Double valuenum;
         if (StringUtils.isBlank(rs.getString("VALUENUM"))) {
-            valuenum = Float.MAX_VALUE;
+        	valuenum = null;
         } else {
-            valuenum = Float.parseFloat(rs.getString("VALUENUM").trim());
+            valuenum = Double.parseDouble(rs.getString("VALUENUM").trim());
         }
         String valueuom = ResultSetUtil.getStringOrBlank(rs, "VALUEUOM").trim().replace("\"", "");
         String flag = ResultSetUtil.getStringOrBlank(rs, "FLAG").trim().replace("\"", "");

--- a/src/main/java/org/jax/lab2hpo/LabEvents2HpoFactory.java
+++ b/src/main/java/org/jax/lab2hpo/LabEvents2HpoFactory.java
@@ -1,5 +1,10 @@
 package org.jax.lab2hpo;
 
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.dstu3.model.Coding;
 import org.jax.Entity.LabEvent;
@@ -14,11 +19,6 @@ import org.monarchinitiative.loinc2hpo.loinc.LoincEntry;
 import org.monarchinitiative.loinc2hpo.loinc.LoincId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
 
 /**
  * Class that does the heavy lifting in this project: convert a labevent into HPO.
@@ -154,7 +154,7 @@ public class LabEvents2HpoFactory {
         //System.out.println(labEvent.getItem_id() + "\t" + labEvent.getValue() + "\t" + labEvent.getValue_num() + "\t" + labEvent.getFlag());
         //we try to parse the value
         Optional<String> code = ordTextualResult(labEvent);
-        if (!code.isPresent() && labEvent.getValue_num() != Double.MAX_VALUE && labSummary != null) {
+        if (!code.isPresent() && labEvent.getValue_num() != null && labSummary != null) {
             System.out.println("Ord having numeric result: " + labEvent.getItem_id() + "\t" + labEvent.getValue() + "\t" + labEvent.getValue_num() + "\t" + labEvent.getFlag());
             return Optional.empty();
         }
@@ -211,10 +211,16 @@ public class LabEvents2HpoFactory {
         }
         double min_normal = normalRange.getMin();
         double max_normal = normalRange.getMax();
-        double observed_value = labEvent.getValue_num();
+        
+        if (labEvent.getValue_num() == null) {
+        	return Optional.empty();
+        }
+
+        Double observed_value = Double.valueOf(labEvent.getValue_num());
+
         String flag = labEvent.getFlag();
         String code = null;
-
+        
         if (observed_value < min_normal) {
             code = "L";
         } else if (observed_value > max_normal) {


### PR DESCRIPTION
Using Float.MAX resulted in us accidentally mapping some empty valuenums to a high HPO term.